### PR TITLE
Generate jenkins.scheme.org nginx.conf

### DIFF
--- a/nginx.scm
+++ b/nginx.scm
@@ -239,6 +239,21 @@
                    (http-block-common-part)
                    http-block-extra))))))))
 
+(define (write-jenkins-nginx-conf)
+  (write-host-nginx-conf
+   "jenkins.scheme.org"
+   "jenkins"
+   (list
+
+    (https-server
+     '("jenkins.scheme.org")
+     (log-directives "jenkins.scheme.org")
+     (block "location /"
+            "proxy_pass http://localhost:8080;"
+            "proxy_set_header Host $host;"
+            "proxy_set_header X-Real-IP $remote_addr;"
+            "proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;")))))
+
 (define (write-tuonela-nginx-conf)
   (write-host-nginx-conf
    "tuonela.scheme.org"
@@ -419,4 +434,5 @@
     (http-redirect-only-server
      "play.scheme.org" "https://try.scheme.org/"))))
 
+(write-jenkins-nginx-conf)
 (write-tuonela-nginx-conf)

--- a/schemeorg.scm
+++ b/schemeorg.scm
@@ -298,6 +298,7 @@
        sudo
        firewall
        docker
+       nginx
        sshd))
 
      (play


### PR DESCRIPTION
@Retropikzel I ran `./schemeorg.sh` which generates the config and uses Ansible to apply it to the server.

Incredibly, everything seems to work fine on the first try. Let me know if something broke.

You stored the existing config in the file `/etc/nginx/sites-enabled/jenkins.scheme.org`, leaving `/etc/nginx.conf` unchanged. This is often good practice, but the scheme.org configs are complex enough that we generate a monolithic `/etc/nginx.conf` that covers all sites on the server. I recall I started out using `sites-enabled` but it made it hard to validate the configs. We have Ansible set up to run the nginx validator before it installs a new config, so that an invalid config is never installed. This is important for high-traffic sites.