### PR TITLE
Added job for monorepo

### DIFF
--- a/jenkins/config/jenkins.yml
+++ b/jenkins/config/jenkins.yml
@@ -212,3 +212,22 @@ jobs:
           }
         }
       }
+  - script: >
+      folder('scheme_containers') {
+        displayName: 'scheme_containers'
+      }
+  - script: >
+      multibranchPipelineJob('scheme_containers/monorepo') {
+        displayName: 'monorepo'
+        branchSources {
+          git {
+              id('git')
+              remote('https://github.com/schemeorg-community/server-configuration.git')
+          }
+        }
+        orphanedItemStrategy {
+          discardOldItems {
+              numToKeep(10)
+          }
+        }
+      }


### PR DESCRIPTION
This adds the job for the Scheme containers monorepo. I have Jenkinsfile in one branch where automation to build images is being developed. I want to get the jenkins job as early as possible so I do not have to build images on my machine and so I can test actually in Jenkins because thats where the builds will be done in the future.